### PR TITLE
remove legacy/undefined CvArr reference in window_QT.h

### DIFF
--- a/modules/highgui/src/window_QT.h
+++ b/modules/highgui/src/window_QT.h
@@ -459,7 +459,7 @@ public:
     double getRatio() CV_OVERRIDE;
     void setRatio(int flags) CV_OVERRIDE;
 
-    void updateImage(const CvArr* arr) CV_OVERRIDE;
+    void updateImage(cv::InputArray arr) CV_OVERRIDE;
 
     void startDisplayInfo(QString text, int delayms) CV_OVERRIDE;
 


### PR DESCRIPTION
Some legacy data structures (including CvArr) were removed in 5.x one instance was missed in:
modules/highgui/src/window_QT.h

`void updateImage(const CvArr* arr) CV_OVERRIDE;`

should be changed to:

`void updateImage(cv::InputArray arr) CV_OVERRIDE;`