### PR TITLE
workaround for build failures: disable unicode defines in QT.

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -83,6 +83,10 @@ endif()
 
 ocv_target_compile_definitions(${the_module} PRIVATE OPENCV_MODULE_IS_PART_OF_WORLD=1)
 
+# https://github.com/opencv/opencv/issues/25543
+qt_disable_unicode_defines(${the_module})
+
+
 if(BUILD_opencv_imgcodecs AND OPENCV_MODULE_opencv_imgcodecs_IS_PART_OF_WORLD)
   ocv_imgcodecs_configure_target()
 endif()


### PR DESCRIPTION
workaround for main repo issue https://github.com/opencv/opencv/issues/25543

disable QT unicode defines in cmake.

in modules/world/CMakeLists.txt:

right below this line:
```
ocv_target_compile_definitions(${the_module} PRIVATE OPENCV_MODULE_IS_PART_OF_WORLD=1)
```

add this line:
```
qt_disable_unicode_defines(${the_module})
```


